### PR TITLE
[Keymap] Added french Bépo support on Ergo42 keeb (#5986)

### DIFF
--- a/keyboards/ergo42/keymaps/shinze/config.h
+++ b/keyboards/ergo42/keymaps/shinze/config.h
@@ -1,0 +1,33 @@
+/*
+This is the c configuration file for the keymap
+
+Copyright 2012 Jun Wako <wakojun@gmail.com>
+Copyright 2015 Jack Humbert
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+/* Use I2C or Serial, not both */
+
+#define USE_SERIAL
+// #define USE_I2C
+
+/* Select hand configuration */
+
+#define MASTER_LEFT
+// #define MASTER_RIGHT
+// #define EE_HANDS
+

--- a/keyboards/ergo42/keymaps/shinze/keymap.c
+++ b/keyboards/ergo42/keymaps/shinze/keymap.c
@@ -1,0 +1,39 @@
+#include QMK_KEYBOARD_H
+#include "keymap_bepo.h"
+#include "keymap_french.h"
+
+extern keymap_config_t keymap_config;
+
+#define BASE 0
+#define NUMB 1
+#define SHORT 2
+
+// Special keys
+#define COPY     RGUI(BP_C)
+#define PASTE    RGUI(BP_V)
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+  [BASE] = LAYOUT( \
+    KC_TAB,    BP_B,    BP_ECUT, BP_P,    BP_O,    BP_EGRV, KC_ESC,      KC_BSPC, BP_DCRC, BP_V,    BP_D,    BP_L,    BP_J,    BP_Z,    \
+    BP_W,      BP_A,    BP_U,    BP_I,    BP_E,    BP_COMM, _______,     _______, BP_C,    BP_T,    BP_S,    BP_R,    BP_N,    BP_M,    \
+    KC_LSFT,   BP_AGRV, BP_Y,    BP_X,    BP_DOT,  BP_K,    _______,     _______, BP_APOS, BP_Q,    BP_G,    BP_H,    BP_F,    BP_CCED, \
+    MO(SHORT), KC_LCTL, _______, KC_LALT, KC_LGUI, KC_SPC,  MO(NUMB),    KC_RGUI, KC_RSFT, KC_SPC,  _______, _______, _______, _______  \
+  ),
+
+  [NUMB] = LAYOUT( \
+    BP_HASH, BP_DQOT, BP_LDQT, BP_RDQT, BP_LPRN, BP_RPRN, BP_AT,         BP_PLUS, BP_MINS, BP_SLSH, BP_ASTR, BP_EQL,  BP_PERC, KC_BSPC, \
+    BP_DLR,  BP_1,    BP_2,    BP_3,    BP_4,    BP_5,    KC_LBRC,       KC_RBRC, BP_6,    BP_7,    BP_8,    BP_9,    BP_0,    BP_DEGR, \
+    _______, _______, _______, _______, _______, _______, _______,       _______, _______, _______, _______, _______, _______, _______, \
+    _______, _______, _______, _______, _______, _______, _______,       _______, _______, _______, _______, _______, _______, _______  \
+  ),
+
+  [SHORT] = LAYOUT( \
+    _______, _______, _______, _______,  _______, _______, _______,    _______, _______, _______, _______, _______, _______, RESET,   \
+    _______, _______, KC_UP,   _______,  _______, _______, _______,    _______, _______, _______, _______, _______, _______, _______, \
+    _______, KC_LEFT, KC_DOWN, KC_RIGHT, _______, _______, _______,    _______, _______, _______, _______, _______, _______, _______, \
+    _______, _______, COPY,    PASTE,    _______, _______, _______,    _______, _______, _______, _______, _______, _______, _______  \
+  )
+
+};
+


### PR DESCRIPTION
* Added french Bépo support on Ergo42 keeb

* Fixed some typos

* Removed a unused include

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
