### PR TITLE
Waldo LAYOUT_60_hhkb bugfix (#6000)

### DIFF
--- a/keyboards/waldo/waldo.h
+++ b/keyboards/waldo/waldo.h
@@ -3,61 +3,61 @@
 #include "quantum.h"
 
 #define LAYOUT_60_ansi( \
-	k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, k0c, k0d, \
-	k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, k1c, k1d, \
-	k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, k2d,      \
-	k30, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b, k3c,           \
+    k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, k0c, k0d, \
+    k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, k1c, k1d, \
+    k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, k2d,      \
+    k30, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b, k3c,           \
     k40, k41, k42, k46, k49, k4a, k4c, k4d                                \
 ) \
 { \
-	{ k00, k01,   k02, k03,   k04,   k05,   k06, k07,   k08,   k09, k0a, k0b,   k0c,   k0d,   KC_NO }, \
-	{ k10, k11,   k12, k13,   k14,   k15,   k16, k17,   k18,   k19, k1a, k1b,   k1c,   k1d,   KC_NO }, \
-	{ k20, k21,   k22, k23,   k24,   k25,   k26, k27,   k28,   k29, k2a, k2b,   KC_NO, k2d,   KC_NO }, \
-	{ k30, KC_NO, k32, k33,   k34,   k35,   k36, k37,   k38,   k39, k3a, k3b,   k3c,   KC_NO, KC_NO }, \
+    { k00, k01,   k02, k03,   k04,   k05,   k06, k07,   k08,   k09, k0a, k0b,   k0c,   k0d,   KC_NO }, \
+    { k10, k11,   k12, k13,   k14,   k15,   k16, k17,   k18,   k19, k1a, k1b,   k1c,   k1d,   KC_NO }, \
+    { k20, k21,   k22, k23,   k24,   k25,   k26, k27,   k28,   k29, k2a, k2b,   KC_NO, k2d,   KC_NO }, \
+    { k30, KC_NO, k32, k33,   k34,   k35,   k36, k37,   k38,   k39, k3a, k3b,   k3c,   KC_NO, KC_NO }, \
     { k40, k41,   k42, KC_NO, KC_NO, KC_NO, k46, KC_NO, KC_NO, k49, k4a, KC_NO, k4c,   k4d,   KC_NO }  \
 }
 
 #define LAYOUT_60_hhkb( \
-	k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, k0c, k0d, k0e, \
-	k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, k1c, k1d,      \
-	k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, k2d,           \
-	k30, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b, k3c, k3d,           \
-   	k41, k42, k46, k49, k4a                                                    \
+    k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, k0c, k0d, k0e, \
+    k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, k1c, k1d,      \
+    k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, k2d,           \
+    k30, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b, k3c, k3d,           \
+    k41, k42, k46, k49, k4a                                                    \
 ) \
 { \
-	{ k00,   k01,   k02, k03,   k04,   k05,   k06, k07,   k08,   k09, k0a, k0b,   k0c,    k0d,   k0e   }, \
-	{ k10,   k11,   k12, k13,   k14,   k15,   k16, k17,   k18,   k19, k1a, k1b,   k1c,    k1d,   KC_NO }, \
-	{ k20,   k21,   k22, k23,   k24,   k25,   k26, k27,   k28,   k29, k2a, k2b,   KC_NO,  k2d,   KC_NO }, \
-	{ k30,   KC_NO, k32, k33,   k34,   k35,   k36, k37,   k38,   k39, k3a, k3b,   k3c,    k3d,   KC_NO }, \
-    { KC_NO, k41,   k42, KC_NO, KC_NO, KC_NO, k46, KC_NO, KC_NO, k49, k4a, KC_NO, KC_NO,  KC_NO, C_NO  }  \
+    { k00,   k01,   k02, k03,   k04,   k05,   k06, k07,   k08,   k09, k0a, k0b,   k0c,    k0d,   k0e   }, \
+    { k10,   k11,   k12, k13,   k14,   k15,   k16, k17,   k18,   k19, k1a, k1b,   k1c,    k1d,   KC_NO }, \
+    { k20,   k21,   k22, k23,   k24,   k25,   k26, k27,   k28,   k29, k2a, k2b,   KC_NO,  k2d,   KC_NO }, \
+    { k30,   KC_NO, k32, k33,   k34,   k35,   k36, k37,   k38,   k39, k3a, k3b,   k3c,    k3d,   KC_NO }, \
+    { KC_NO, k41,   k42, KC_NO, KC_NO, KC_NO, k46, KC_NO, KC_NO, k49, k4a, KC_NO, KC_NO,  KC_NO, KC_NO }  \
 }
 
 #define LAYOUT_60_ansi_split_bs_rshift( \
-	k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, k0c, k0d, k0e, \
-	k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, k1c, k1d,      \
-	k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, k2d,           \
-	k30, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b, k3c, k3d,           \
+    k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, k0c, k0d, k0e, \
+    k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, k1c, k1d,      \
+    k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, k2d,           \
+    k30, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b, k3c, k3d,           \
     k40, k41, k42, k46, k49, k4a, k4c, k4d                                     \
 ) \
 { \
-	{ k00, k01,   k02, k03,   k04,   k05,   k06, k07,   k08,   k09, k0a, k0b,   k0c,   k0d,   k0e },   \
-	{ k10, k11,   k12, k13,   k14,   k15,   k16, k17,   k18,   k19, k1a, k1b,   k1c,   k1d,   KC_NO }, \
-	{ k20, k21,   k22, k23,   k24,   k25,   k26, k27,   k28,   k29, k2a, k2b,   KC_NO, k2d,   KC_NO }, \
-	{ k30, KC_NO, k32, k33,   k34,   k35,   k36, k37,   k38,   k39, k3a, k3b,   k3c,   k3d,   KC_NO }, \
+    { k00, k01,   k02, k03,   k04,   k05,   k06, k07,   k08,   k09, k0a, k0b,   k0c,   k0d,   k0e },   \
+    { k10, k11,   k12, k13,   k14,   k15,   k16, k17,   k18,   k19, k1a, k1b,   k1c,   k1d,   KC_NO }, \
+    { k20, k21,   k22, k23,   k24,   k25,   k26, k27,   k28,   k29, k2a, k2b,   KC_NO, k2d,   KC_NO }, \
+    { k30, KC_NO, k32, k33,   k34,   k35,   k36, k37,   k38,   k39, k3a, k3b,   k3c,   k3d,   KC_NO }, \
     { k40, k41,   k42, KC_NO, KC_NO, KC_NO, k46, KC_NO, KC_NO, k49, k4a, KC_NO, k4c,   k4d,   KC_NO }  \
 }
 
 #define LAYOUT_all( \
-	k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, k0c, k0d, k0e, \
-	k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, k1c, k1d,      \
-	k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, k2c, k2d,      \
-	k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b, k3c, k3d,      \
+    k00, k01, k02, k03, k04, k05, k06, k07, k08, k09, k0a, k0b, k0c, k0d, k0e, \
+    k10, k11, k12, k13, k14, k15, k16, k17, k18, k19, k1a, k1b, k1c, k1d,      \
+    k20, k21, k22, k23, k24, k25, k26, k27, k28, k29, k2a, k2b, k2c, k2d,      \
+    k30, k31, k32, k33, k34, k35, k36, k37, k38, k39, k3a, k3b, k3c, k3d,      \
     k40, k41, k42, k44, k46, k48, k49, k4a, k4c, k4d                           \
 ) \
 { \
-	{ k00, k01, k02, k03,   k04, k05,   k06, k07,   k08, k09, k0a, k0b,   k0c, k0d, k0e   }, \
-	{ k10, k11, k12, k13,   k14, k15,   k16, k17,   k18, k19, k1a, k1b,   k1c, k1d, KC_NO }, \
-	{ k20, k21, k22, k23,   k24, k25,   k26, k27,   k28, k29, k2a, k2b,   k2c, k2d, KC_NO }, \
-	{ k30, k31, k32, k33,   k34, k35,   k36, k37,   k38, k39, k3a, k3b,   k3c, k3d, KC_NO }, \
+    { k00, k01, k02, k03,   k04, k05,   k06, k07,   k08, k09, k0a, k0b,   k0c, k0d, k0e   }, \
+    { k10, k11, k12, k13,   k14, k15,   k16, k17,   k18, k19, k1a, k1b,   k1c, k1d, KC_NO }, \
+    { k20, k21, k22, k23,   k24, k25,   k26, k27,   k28, k29, k2a, k2b,   k2c, k2d, KC_NO }, \
+    { k30, k31, k32, k33,   k34, k35,   k36, k37,   k38, k39, k3a, k3b,   k3c, k3d, KC_NO }, \
     { k40, k41, k42, KC_NO, k44, KC_NO, k46, KC_NO, k48, k49, k4a, KC_NO, k4c, k4d        }  \
 }


### PR DESCRIPTION
* Fix typo in LAYOUT_60_hhkb macro

Reported by Sushiimi
- https://github.com/qmk/qmk_configurator/issues/376

* Unify white space

Tabs and spaces were being mixed for indenting.

No logic change.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
