### PR TITLE
[Keyboard] niu_mini uses dfu bootloader rather than the afrdude bootl…

### DIFF
--- a/keyboards/niu_mini/readme.md
+++ b/keyboards/niu_mini/readme.md
@@ -11,6 +11,6 @@ Hardware Availability: [KBDFans](https://kbdfans.myshopify.com/products/niu-mini
 
 Make example for this keyboard (after setting up your build environment):
 
-    make niu_mini:default:avrdude
+    make niu_mini:default:dfu
 
 See [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) then the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information.

--- a/keyboards/niu_mini/rules.mk
+++ b/keyboards/niu_mini/rules.mk
@@ -44,7 +44,7 @@ OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 #   Atmel DFU loader 4096
 #   LUFA bootloader  4096
 #   USBaspLoader     2048
-OPT_DEFS += -DBOOTLOADER_SIZE=4096
+BOOTLOADER = atmel-dfu
 
 # Build Options
 #   change to "no" to disable the options, or define them in the Makefile in


### PR DESCRIPTION
…oader (#6092)

* niu_mini uses dfu bootloader rather than the afrdude bootloader
	modified: readme.md

* Change rules in rules.mk to reflect the bootloader change
	modified:   keyboards/niu_mini/rules.mk

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
