### PR TITLE
(OLED) Added support for CR (#6399)

### DIFF
--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -321,7 +321,7 @@ void oled_render(void) {
 
     // Send render data chunk after rotating
     if (I2C_WRITE_REG(I2C_DATA, &temp_buffer[0], OLED_BLOCK_SIZE) != I2C_STATUS_SUCCESS) {
-      print("oled_render data failed\n");
+      print("oled_render90 data failed\n");
       return;
     }
   }
@@ -390,6 +390,11 @@ void oled_write_char(const char data, bool invert) {
   if (data == '\n') {
     // Old source wrote ' ' until end of line...
     oled_advance_page(true);
+    return;
+  }
+
+  if (data == '\r') {
+    oled_advance_page(false);
     return;
   }
 


### PR DESCRIPTION
Currently OLED Dirver only supports LF (\n) character in a string to clear out the rest of the current line and advance to the next line for writing. This PR adds support for CR (\r) character as well to advance to the next line, however not clear out the rest of the current line. This is extremely useful when you want to display a multi-line logo using a single array without wiping out exiting lines and flagging the OLED as dirty unnecessarily.