### PR TITLE
 Fix Clueboard hotswap gen1 not compiling when LED Matrix is disabled…

### DIFF
--- a/keyboards/clueboard/66_hotswap/gen1/gen1.c
+++ b/keyboards/clueboard/66_hotswap/gen1/gen1.c
@@ -14,15 +14,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "gen1.h"
-#include "is31fl3731-simple.h"
-
-void matrix_init_kb(void) {
-}
-
-void matrix_scan_kb(void) {
-}
 
 #ifdef LED_MATRIX_ENABLE
+    #include "is31fl3731-simple.h"
+
 const is31_led g_is31_leds[LED_DRIVER_LED_COUNT] = {
 /* Refer to IS31 manual for these locations
  *  driver


### PR DESCRIPTION
… (#6427)

* Fix Clueboard hotswap gen1 not compiling when LED Matrix is disabled

* Move keymap.json to default keymap folder

* Revert "Move keymap.json to default keymap folder"

This reverts commit 7f28df909d7e4dcc79ab0ff44fe264656b5dfa18.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
