### PR TITLE
Align flashing behaviour of dfu-util (#6578)

### DIFF
--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -171,7 +171,5 @@ Flashing sequence:
 
 There are a number of DFU commands that you can use to flash firmware to a STM32 device:
 
-* `:dfu-util` - The default command for flashing to STM32 devices. 
-* `:dfu-util-wait` - This works like the default command, but it gives you a (configurable) 10 second timeout before it attempts to flash the firmware.  You can use `TIME_DELAY=20` from the command line to change the timeout.
-   * Eg: `make <keyboard>:<keymap>:dfu-util TIME_DELAY=5`
-* `:st-link-cli` - This allows you to flash the firmware via ST-LINK's CLI utility, rather than dfu-util. 
+* `:dfu-util` - The default command for flashing to STM32 devices.
+* `:st-link-cli` - This allows you to flash the firmware via ST-LINK's CLI utility, rather than dfu-util.

--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -235,28 +235,18 @@ qmk: $(BUILD_DIR)/$(TARGET).bin
 	printf "@ $(TARGET).json\n@=info.json\n" | zipnote -w $(TARGET).qmk
 
 define EXEC_DFU_UTIL
+	until $(DFU_UTIL) -l | grep -q "Found DFU"; do\
+		echo "Error: Bootloader not found. Trying again in 5s." ;\
+		sleep 5 ;\
+	done
 	$(DFU_UTIL) $(DFU_ARGS) -D $(BUILD_DIR)/$(TARGET).bin
 endef
 
 dfu-util: $(BUILD_DIR)/$(TARGET).bin cpfirmware sizeafter
 	$(call EXEC_DFU_UTIL)
 
-ifneq ($(strip $(TIME_DELAY)),)
-  TIME_DELAY = $(strip $(TIME_DELAY))
-else
-  TIME_DELAY = 10
-endif
-dfu-util-wait: $(BUILD_DIR)/$(TARGET).bin cpfirmware sizeafter
-	echo "Preparing to flash firmware. Please enter bootloader now..." ;\
-  COUNTDOWN=$(TIME_DELAY) ;\
-  while [[ $$COUNTDOWN -ge 1 ]] ; do \
-        echo "Flashing in $$COUNTDOWN ..."; \
-        sleep 1 ;\
-        ((COUNTDOWN = COUNTDOWN - 1)) ; \
-  done; \
-  echo "Flashing $(TARGET).bin" ;\
-  sleep 1 ;\
-  $(call EXEC_DFU_UTIL)
+# Legacy alias
+dfu-util-wait: dfu-util
 
 st-link-cli: $(BUILD_DIR)/$(TARGET).hex sizeafter
 	$(ST_LINK_CLI) $(ST_LINK_ARGS) -q -c SWD -p $(BUILD_DIR)/$(TARGET).hex -Rst


### PR DESCRIPTION
* Align flashing retry logic of dfu-util

* Align bootloader wait messages

Co-Authored-By: Drashna Jaelre <drashna@live.com>

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
