### PR TITLE
Decrement EECONFIG magic number

### DIFF
--- a/tmk_core/common/eeconfig.h
+++ b/tmk_core/common/eeconfig.h
@@ -22,7 +22,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdbool.h>
 
 
-#define EECONFIG_MAGIC_NUMBER                       (uint16_t)0xFEED
+#ifndef EECONFIG_MAGIC_NUMBER
+#     define EECONFIG_MAGIC_NUMBER                       (uint16_t)0xFEEC
+#endif
 #define EECONFIG_MAGIC_NUMBER_OFF                   (uint16_t)0xFFFF
 
 /* EEPROM parameter address */


### PR DESCRIPTION
This will manually wipe the EEPROM. This is a hacky solution for when new ranges are added or moved around. 

A better (more complicated) solution would be to zero out everything, not just known ranges.  But for now, this is a hacky solution that will work.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
